### PR TITLE
Use shellshock publish release command

### DIFF
--- a/.github/workflows/_create_release.yaml
+++ b/.github/workflows/_create_release.yaml
@@ -64,9 +64,5 @@ jobs:
       - name: Create GitHub Release
         id: publish
         run: |
-          TAG="v$(jq -r '.latest' manifest.json)"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --generate-notes \
-            violet
+          echo "tag=v$(jq -r '.latest' manifest.json)" >> "$GITHUB_OUTPUT"
+          ./shell/shock publish-release violet

--- a/manifest.json
+++ b/manifest.json
@@ -3,5 +3,10 @@
   "org": "kernelle-soft",
   "repo": "violet",
   "latest": "0.0.1-dev.1",
-  "stable": ""
+  "stable": "",
+  "naming": {
+    "major": "Early Development",
+    "minor": "Go Rewrite",
+    "patch": "Initial Scaffolding"
+  }
 }


### PR DESCRIPTION
This pull request updates the release workflow and metadata for the project, focusing on improving release management and providing better context for versioning. The most important changes are grouped below:

**Release Workflow Improvements:**

* The GitHub release creation step in `.github/workflows/_create_release.yaml` now uses the custom `./shell/shock publish-release` script instead of the standard `gh release create` command, streamlining and potentially customizing the release process.

**Metadata and Versioning Enhancements:**

* The `manifest.json` file now includes a new `naming` object that describes the meaning of each version segment (`major`, `minor`, `patch`), providing clearer context for release versions.

**Submodule Update:**

* The `shell/.shock` submodule was updated to a newer commit, which may bring in bug fixes or new features for release publishing.